### PR TITLE
POL-194: use diet on calender

### DIFF
--- a/src/pages/calender.js
+++ b/src/pages/calender.js
@@ -11,47 +11,30 @@ import {CALENDAR_PASSED_KEY, CALENDAR_TIMESTAMP_KEY} from "../utils/constants";
 import {SearchFilter} from "../components/search"
 import ReactTooltip from 'react-tooltip';
 
-export const getLatestRound = (roundName) => {
-    return roundName.match(/\d+/)[0];
-}
-
-export const getBillClassName = (billType) => {
-    if (billType === "参法") {
-        return "sanhou"
-    } else if (billType === "衆法") {
-        return "shuhou"
-    } else {
-        return "kakuhou"
-    }
-}
-
 export const getType = (bill) => {
     return bill.billNumber.match(/.法/)[0];
 }
 
 export const appearAfterRoundStart = (bill, roundStartDate) => {
     const roundStart = roundStartDate.getTime();
-    return toJsDate(bill.submittedDate).getTime() >= roundStart || toJsDate(bill.proclaimedDate).getTime() >= roundStart || toJsDate(bill.passedRepresentativesDate).getTime() >= roundStart || toJsDate(bill.passedCouncilorsDate).getTime() >= roundStart
+    return toJsDate(bill.submittedDate).getTime() >= roundStart
+        || toJsDate(bill.proclaimedDate).getTime() >= roundStart
+        || toJsDate(bill.passedRepresentativesDate).getTime() >= roundStart
+        || toJsDate(bill.passedCouncilorsDate).getTime() >= roundStart
 }
 
-export const getGroups = (bills, round, filterPassed, roundStart) => {
+export const getGroups = (bills) => {
     return bills
-        .filter((bill) => {
-            return appearAfterRoundStart(bill, roundStart) && (!filterPassed || bill.isPassed)
-        })
         .map((bill, index) => {
             const deliberationPeriod = bill.proclaimedDate ? (toJsDate(bill.proclaimedDate) - toJsDate(bill.submittedDate)) / 86400000 + "日" : "未公布"
             const startDate = toJsDate(bill.submittedDate);
             const endDate = toJsDate(bill.proclaimedDate);
-            return { id: index, title: bill.name, internalId: bill.id, tip: bill.billNumber, rightTitle: deliberationPeriod, startDate: startDate, endDate: endDate, proclaimed: bill.proclaimedDate, billType: getType(bill) }
+            return { id: index, title: bill.name, internalId: bill.id, tip: bill.billNumber, rightTitle: deliberationPeriod, startDate: startDate, endDate: endDate, proclaimed: bill.proclaimedDate, billType: getType(bill), category: bill.category }
         });
 }
 
-export const getItems = (bills, round, filterPassed, roundStart) => {
+export const getItems = (bills) => {
     const nested_items = bills
-        .filter((bill) => {
-            return appearAfterRoundStart(bill, roundStart) && (!filterPassed || bill.isPassed)
-        })
         .map((bill, index) => {
             return [
                 { id: null, group: index, title: "", start_time: toJsDate(bill.submittedDate), end_time: toJsDate(bill.submittedDate), color: 'rgb(158, 14, 206)', itemProps: { style: {background: '#93c47dff', border: 0, cursor: "auto"}} },
@@ -60,9 +43,9 @@ export const getItems = (bills, round, filterPassed, roundStart) => {
                 { id: null, group: index, title: "", start_time: toJsDate(bill.proclaimedDate), end_time: toJsDate(bill.proclaimedDate), itemProps: { style: {background: '#c27ba0ff', border: 0, cursor: "auto"}} }]
         });
     const flat_items = [].concat(...nested_items);
-    return flat_items.map((bill, index) => {
-        bill["id"] = index;
-        return bill;
+    return flat_items.map((item, index) => {
+        item["id"] = index;
+        return item;
     })
 }
 
@@ -92,10 +75,13 @@ export default class App extends React.Component {
     render() {
         const diet = this.props.data.politylink.Diet[0];
         const timeStart = toJsDate(diet.startDate);
-        const latestRound = getLatestRound(diet.name);
+        const latestRound = diet.number;
+        const bills = diet.bills.filter((bill) => {
+            return appearAfterRoundStart(bill, timeStart) && (!this.state.filterPassed || bill.isPassed)
+        });
 
-        const groups = getGroups(diet.bills, latestRound, this.state.filterPassed, timeStart);
-        const items = getItems(diet.bills, latestRound, this.state.filterPassed, timeStart);
+        const groups = getGroups(bills);
+        const items = getItems(bills);
 
         let groupRenderer = ({ group, isRightSidebar }) => {
             if (isRightSidebar) {
@@ -107,7 +93,7 @@ export default class App extends React.Component {
             } else {
                 return (
                     <div className="rct-sidebar-row-item">
-                        <span className={getBillClassName(group.billType)}>{group.billType}</span>
+                        <span className={group.category.toLowerCase()}>{group.billType}</span>
                         <Link data-tip={group.title + "<br />"+ group.tip} to={buildPath(group.internalId)}>
                             <span>{group.title}</span>
                         </Link>
@@ -169,10 +155,12 @@ export const query = graphql`
         politylink {
             Diet (orderBy:[startDate_desc], first:1) {
                 name
+                number
                 startDate {year, month, day}
                 bills (orderBy:[submittedDate_asc]) {
                     id
                     name
+                    category
                     billNumber
                     submittedDate {year, month, day}
                     passedRepresentativesCommitteeDate {year, month, day}

--- a/src/utils/dateutils.js
+++ b/src/utils/dateutils.js
@@ -1,5 +1,5 @@
 const toJsDate = (gqlDate) => {
-    return new Date(gqlDate.year, gqlDate.month - 1, gqlDate.day)
+    return gqlDate ? new Date(gqlDate.year, gqlDate.month - 1, gqlDate.day) : new Date(null)
 }
 
 const offsetDate = (jsDate, offset) => {


### PR DESCRIPTION
<img width="784" alt="スクリーンショット 2021-01-20 13 01 56" src="https://user-images.githubusercontent.com/12047794/105125442-b55fcb80-5b1f-11eb-9c93-ca77e0021594.png">

現時点で法律案カレンダーの国会会期は、開始日と終了日が決め打ちとなっているが、これは自動で更新できないという問題がある。

Diet リソースとBillが紐付いているので、法律案カレンダーの国会会期や、その国会の中で審議された法律案の一覧を Diet から取得できるようになる。

`src/utils/dateutils.js` で、 gqlDate が null の場合にエラーで落ちてしまうことがあったので、それを防ぐために、nullの場合はダミーの date を返すよう実装を変更しました。