### PR TITLE
POL-296: Add bill rss feed

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -107,7 +107,7 @@ module.exports = {
                       allSitePage(
                         limit: 15
                         sort: { fields: context___date, order: DESC }
-                        filter: { context: { rss: { eq: true } } }
+                        filter: { context: { rss: { eq: true }, timelineId: { ne: null } } }
                       ) {
                         edges {
                           node {
@@ -122,8 +122,43 @@ module.exports = {
                       }
                     }
                   `,
-                        output: "/rss.xml",
-                        title: "PolityLink RSS Feed",
+                        output: "/timeline_rss.xml",
+                        title: "PolityLink Timeline RSS Feed",
+                    },
+                    {
+                        serialize: ({query: {site, allSitePage}}) => {
+                            return allSitePage.edges.map(({node}) => {
+                                return {
+                                    title: node.context.title,
+                                    description: node.context.description,
+                                    date: new Date(node.context.date), //(formatString: "ddd, DD MMM YYYY, h:mm:ss +0900")
+                                    url: site.siteMetadata.siteUrl + node.path,
+                                    guid: site.siteMetadata.siteUrl + node.path,
+                                }
+                            })
+                        },
+                        query: `
+                    {
+                      allSitePage(
+                        limit: 15
+                        sort: { fields: context___date, order: DESC }
+                        filter: { context: { rss: { eq: true }, billId: { ne: null } } }
+                      ) {
+                        edges {
+                          node {
+                            path
+                            context {
+                                title
+                                date
+                                description
+                            }
+                          }
+                        }
+                      }
+                    }
+                  `,
+                        output: "/bill_rss.xml",
+                        title: "PolityLink Bill RSS Feed",
                     }
                 ]
             }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -107,7 +107,7 @@ module.exports = {
                       allSitePage(
                         limit: 15
                         sort: { fields: context___date, order: DESC }
-                        filter: { context: { rss: { eq: true }, timelineId: { ne: null } } }
+                        filter: { context: { rss: { eq: true } } }
                       ) {
                         edges {
                           node {
@@ -122,43 +122,8 @@ module.exports = {
                       }
                     }
                   `,
-                        output: "/timeline_rss.xml",
-                        title: "PolityLink Timeline RSS Feed",
-                    },
-                    {
-                        serialize: ({query: {site, allSitePage}}) => {
-                            return allSitePage.edges.map(({node}) => {
-                                return {
-                                    title: node.context.title,
-                                    description: node.context.description,
-                                    date: new Date(node.context.date), //(formatString: "ddd, DD MMM YYYY, h:mm:ss +0900")
-                                    url: site.siteMetadata.siteUrl + node.path,
-                                    guid: site.siteMetadata.siteUrl + node.path,
-                                }
-                            })
-                        },
-                        query: `
-                    {
-                      allSitePage(
-                        limit: 15
-                        sort: { fields: context___date, order: DESC }
-                        filter: { context: { rss: { eq: true }, billId: { ne: null } } }
-                      ) {
-                        edges {
-                          node {
-                            path
-                            context {
-                                title
-                                date
-                                description
-                            }
-                          }
-                        }
-                      }
-                    }
-                  `,
-                        output: "/bill_rss.xml",
-                        title: "PolityLink Bill RSS Feed",
+                        output: "/rss.xml",
+                        title: "PolityLink RSS Feed",
                     }
                 ]
             }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,5 @@
 const {buildPath} = require(`./src/utils/urlutils`)
-const {toJsDate, formatDateWithDay, formatDate} = require(`./src/utils/dateutils`)
+const {toJsDate, formatDateWithDay} = require(`./src/utils/dateutils`)
 
 const path = require(`path`)
 
@@ -27,7 +27,7 @@ exports.createPages = async ({actions, graphql}) => {
                 title: name,
                 description: formatBillRssText(name, proclaimedDate),
                 date: toJsDate(proclaimedDate),
-                rss: proclaimedDate && true
+                rss: Boolean(proclaimedDate)
             },
         })
     })
@@ -182,5 +182,5 @@ const formatTimelineRssText = (timeline) => {
 }
 
 const formatBillRssText = (name, date) => {
-    return `${name}が${formatDate(date)}に公布されました。詳細情報を PolityLink で確認できます。`;
+    return `${name}が${formatDateWithDay(date)}に公布されました。詳細情報をPolityLinkで確認できます。`;
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,5 @@
 const {buildPath} = require(`./src/utils/urlutils`)
-const {toJsDate, formatDateWithDay} = require(`./src/utils/dateutils`)
+const {toJsDate, formatDateWithDay, formatDate} = require(`./src/utils/dateutils`)
 
 const path = require(`path`)
 
@@ -25,7 +25,7 @@ exports.createPages = async ({actions, graphql}) => {
             context: {
                 billId: id,
                 title: name,
-                description: formatBillRssText(name),
+                description: formatBillRssText(name, proclaimedDate),
                 date: toJsDate(proclaimedDate),
                 rss: proclaimedDate && true
             },
@@ -181,6 +181,6 @@ const formatTimelineRssText = (timeline) => {
     return `国会開催日です。現時点で${minutesStr}が登録されています。`;
 }
 
-const formatBillRssText = (name) => {
-    return `${name}が公布されました。法律案成立までの詳細情報を PolityLink で確認できます。`;
+const formatBillRssText = (name, date) => {
+    return `${name}が${formatDate(date)}に公布されました。詳細情報を PolityLink で確認できます。`;
 }


### PR DESCRIPTION
法律案のうち、公布されたものがrssフィードで流れる。

例文
> 特定電気通信役務提供者の損害賠償責任の制限及び発信者情報の開示に関する法律の一部を改正する法律案
> 特定電気通信役務提供者の損害賠償責任の制限及び発信者情報の開示に関する法律の一部を改正する法律案が2021/04/28に公布されました。詳細情報を PolityLink で確認できます。 

（公布日に必ずRSSフィードが流れるわけではないので、日付情報をrssフィード内に入れることにしています。）
